### PR TITLE
Add integration test for start scheduler endpoint

### DIFF
--- a/backVLA/springboot/demo/pom.xml
+++ b/backVLA/springboot/demo/pom.xml
@@ -26,11 +26,16 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+                <dependency>
+                        <groupId>com.mysql</groupId>
+                        <artifactId>mysql-connector-j</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/backVLA/springboot/demo/src/test/java/com/example/demo/api/VLAControllerIntegrationTest.java
+++ b/backVLA/springboot/demo/src/test/java/com/example/demo/api/VLAControllerIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.example.demo.api;
+
+import com.example.demo.api.service.VLAService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class VLAControllerIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private VLAService vlaService;
+
+    @AfterEach
+    void tearDown() {
+        vlaService.stopScheduler();
+    }
+
+    @Test
+    void startEndpointReturnsIdAndStartsScheduler() {
+        ResponseEntity<Map> response = restTemplate.postForEntity("/api/VLA/start", null, Map.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().containsKey("idLancamento"));
+        assertNotNull(response.getBody().get("idLancamento"));
+        assertTrue(vlaService.isSchedulerRunning(), "Scheduler should be running after start");
+    }
+}

--- a/backVLA/springboot/demo/src/test/resources/application.properties
+++ b/backVLA/springboot/demo/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary
- add H2 database for tests
- create Spring Boot test configuration for tests
- implement integration test for `/api/VLA/start`

## Testing
- `./mvnw -version` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f75a3f0832094be0ba226c2d7ba