### PR TITLE
Update README with API port info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🔧 Projeto VLA – Aquisição e Armazenamento de Dados de Sensor
 
 Este projeto consiste em uma **API desenvolvida com Spring Boot** responsável por coletar e armazenar dados de sensores via requisições HTTP, juntamente com um **servidor Python** que simula um dispositivo físico (como um ESP) enviando dados a cada 100ms em formato JSON.
+Por padrão, a API Spring Boot escuta na porta **8089**.
 
 ---
 
@@ -25,6 +26,7 @@ Este projeto consiste em uma **API desenvolvida com Spring Boot** responsável p
 ### Inicialização
 
 Executar o "DemoApplication" no Intellij
+Ao iniciar, a API estará acessível em `http://localhost:8089`.
 
 ## 🤖 Simulador de Sensor - Python
 Descrição


### PR DESCRIPTION
## Summary
- state default port 8089 for the Spring Boot API
- mention this endpoint in backend initialization instructions

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f731400832081b179c9fff905ee