### PR TITLE
Fix timestamp deserialization

### DIFF
--- a/backVLA/springboot/demo/src/main/java/com/example/demo/api/dto/SensorsDTO.java
+++ b/backVLA/springboot/demo/src/main/java/com/example/demo/api/dto/SensorsDTO.java
@@ -15,6 +15,8 @@ public class SensorsDTO {
     private GPSDTO gps;
     private Integer esp_now_channel;
     private String mac_address;
-    private Long timestamp;
+    // `timestamp` do simulador vem como valor decimal (segundos com fração).
+    // Usar Double para não perder a parte fracionária ao desserializar.
+    private Double timestamp;
     private LancamentoEntity lancamento;
 }


### PR DESCRIPTION
## Summary
- preserve fractional seconds in `SensorsDTO.timestamp` by using `Double`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687a4a8ab27c8320be206e22f011e78e